### PR TITLE
Move selection criteria to a separate tab

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,9 @@
 <template>
     <GamePicker />
     <TabView>
+        <TabPanel header="Criteria">
+            <SelectionCriteria />
+        </TabPanel>
         <TabPanel header="Games">
             <GameList />
         </TabPanel>
@@ -28,6 +31,7 @@
     import AppSettings from '@/components/AppSettings.vue';
     import GameList from '@/components/GameList.vue';
     import GamePicker from '@/components/GamePicker.vue';
+    import SelectionCriteria from '@/components/SelectionCriteria.vue';
     import { useThemes } from '@/settings/theme';
     import ConfirmDialog from 'primevue/confirmdialog';
     import TabPanel from 'primevue/tabpanel';

--- a/src/assets/base.scss
+++ b/src/assets/base.scss
@@ -10,3 +10,7 @@ body {
     min-height: 100vh;
     text-rendering: optimizeLegibility;
 }
+
+label {
+    font-weight: 700;
+}

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -67,3 +67,9 @@ header {
 .break-word {
     overflow-wrap: break-word;
 }
+
+.sub-title {
+    color: var(--primary-color);
+    font-weight: 500;
+    margin-bottom: 0;
+}

--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -3,22 +3,6 @@
         <p class="sub-title">
             Games Selection
         </p>
-        <label class="md:align-items-center flex flex-column md:flex-row gap-2 justify-content-between">
-            Number of Players
-            <NumericInput
-                v-model="settings.players"
-                class="md:max-w-20rem"
-            />
-        </label>
-        <Divider class="md:block hidden my-0" />
-        <div class="align-items-center flex justify-content-between my-2">
-            <label for="skip-played">Don't Pick Already Played</label>
-            <InputSwitch
-                v-model="settings.skipPlayed"
-                input-id="skip-played"
-            />
-        </div>
-        <Divider class="md:block hidden my-0" />
         <Button
             class="mr-auto md:w-auto w-full"
             label="Reset Played Games"
@@ -29,7 +13,12 @@
             Appearance
         </p>
         <div class="md:align-items-center flex flex-column md:flex-row gap-2 justify-content-between">
-            <label for="theme">Theme</label>
+            <label
+                class="white-space-nowrap"
+                for="theme"
+            >
+                Theme
+            </label>
             <Dropdown
                 v-model="settings.theme"
                 :options="themes"
@@ -43,13 +32,10 @@
 </template>
 
 <script setup lang="ts">
-    import NumericInput from '@/components/NumericInput.vue';
     import { useGamesStore } from '@/stores/games';
     import { useSettingsStore } from '@/stores/settings';
     import Button from 'primevue/button';
-    import Divider from 'primevue/divider';
     import Dropdown from 'primevue/dropdown';
-    import InputSwitch from 'primevue/inputswitch';
     import { useConfirm } from 'primevue/useconfirm';
     import { ref } from 'vue';
 
@@ -71,20 +57,3 @@
         });
     };
 </script>
-
-<style scoped lang="scss">
-    label {
-        font-weight: 700;
-        white-space: nowrap;
-
-        > span {
-            margin-top: 0.5rem;
-        }
-    }
-
-    .sub-title {
-        color: var(--primary-color);
-        font-weight: 500;
-        margin-bottom: 0;
-    }
-</style>

--- a/src/components/EditGame.vue
+++ b/src/components/EditGame.vue
@@ -100,10 +100,6 @@
 <style scoped lang="scss">
     @use 'primeflex/primeflex';
 
-    label {
-        font-weight: 700;
-    }
-
     .players {
         @include primeflex.styleclass('flex flex-column gap-2');
 

--- a/src/components/SelectionCriteria.vue
+++ b/src/components/SelectionCriteria.vue
@@ -1,0 +1,43 @@
+<template>
+    <div class="flex flex-column gap-3">
+        <p class="sub-title">
+            Group
+        </p>
+        <label class="md:align-items-center flex flex-column md:flex-row gap-2 justify-content-between white-space-nowrap">
+            Number of Players
+            <NumericInput
+                v-model="settings.players"
+                class="md:max-w-20rem"
+            />
+        </label>
+        <p class="sub-title">
+            Games Selection
+        </p>
+        <div class="align-items-center flex justify-content-between my-2">
+            <label
+                class="white-space-nowrap"
+                for="skip-played"
+            >
+                Don't Pick Already Played
+            </label>
+            <InputSwitch
+                v-model="settings.skipPlayed"
+                input-id="skip-played"
+            />
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+    import NumericInput from '@/components/NumericInput.vue';
+    import { useSettingsStore } from '@/stores/settings';
+    import InputSwitch from 'primevue/inputswitch';
+
+    const settings = useSettingsStore();
+</script>
+
+<style scoped lang="scss">
+    label > span {
+        margin-top: 0.5rem;
+    }
+</style>


### PR DESCRIPTION
The number of players and the option to not pick alread played games has been moved from the settings tab to a new Criteria tab. This is the tab that is first shown when the app is loaded to make the selection criteria more clear.

Closes #1